### PR TITLE
validation set too large

### DIFF
--- a/deepaugment/build_features.py
+++ b/deepaugment/build_features.py
@@ -96,6 +96,10 @@ class DataOp:
             dict: preprocessed data
         """
 
+        if ( val_set_size > (0.5*train_set_size)):
+            val_set_size = int(0.1*train-set_size)
+        print(f"Using {val_set_size} validation images")
+
         data = DataOp.split_train_val_sets(X, y, train_set_size, val_set_size)
 
         # normalize images


### PR DESCRIPTION
validation set too large for small training sets. 
check if validation set is greater than 1/2 size of training set. If it is make validation set 1/10 size of training set.